### PR TITLE
Enable autocomplete selects on book loan form

### DIFF
--- a/application/modules/livro/forms/Emprestimo.php
+++ b/application/modules/livro/forms/Emprestimo.php
@@ -24,28 +24,28 @@ class Livro_Form_Emprestimo extends Zend_Form {
 
 
         $idTurma = new Zend_Form_Element_Select('idTurma', array("tabindex" => "1",
-                    "title" => "Turma", "class" => "validate[required]"));
+                    "title" => "Turma", "class" => "validate[required] chosen-select"));
         $idTurma->setRequired(true)->setLabel('Turma*:');
         $this->addElement($idTurma);
 
         $noEvangelizando = new Zend_Form_Element_Select('noEvangelizando', array("tabindex" => "2",
-                    "title" => "Evangelizando", "class" => "validate[required]"));
+                    "title" => "Evangelizando", "class" => "validate[required] chosen-select"));
         $noEvangelizando->setRequired(true)->setLabel('Evangelizando*:');
         $noEvangelizando->addMultiOption(NULL, "Selecione a turma...");
         $this->addElement($noEvangelizando);
 
         $idColaborador = new Zend_Form_Element_Select('idColaborador', array("tabindex" => "2",
-                    "title" => "Colaborador", "class" => "validate[required]"));
+                    "title" => "Colaborador", "class" => "validate[required] chosen-select"));
         $idColaborador->setRequired(true)->setLabel('Colaborador*:');
         $this->addElement($idColaborador);
 
         $idLivro = new Zend_Form_Element_Select('idLivro', array("tabindex" => "3",
-                    "title" => "Livro", "class" => "validate[required]"));
+                    "title" => "Livro", "class" => "validate[required] chosen-select"));
         $idLivro->setRequired(true)->setLabel('Livro*:');
         $this->addElement($idLivro);
 
         $nuExemplar = new Zend_Form_Element_Select('nuExemplar', array("tabindex" => "4",
-                    "title" => "Exemplar", "class" => "validate[required]"));
+                    "title" => "Exemplar", "class" => "validate[required] chosen-select"));
         $nuExemplar->setRequired(true)->setLabel('Exemplar*:');
         $this->addElement($nuExemplar);
 
@@ -67,12 +67,12 @@ class Livro_Form_Emprestimo extends Zend_Form {
         $this->addElement($dtPrevDevolucao);
 
         $nuAnoEvangelizando = new Zend_Form_Element_Select('nuAnoEvangelizando', array("tabindex" => "1",
-                    "title" => "Ano"));
+                    "title" => "Ano", "class" => "chosen-select"));
         $nuAnoEvangelizando->setLabel('Ano:');
         $this->addElement($nuAnoEvangelizando);
 
         $nuAnoColaborador = new Zend_Form_Element_Select('nuAnoColaborador', array("tabindex" => "1",
-                    "title" => "Ano"));
+                    "title" => "Ano", "class" => "chosen-select"));
         $nuAnoColaborador->setLabel('Ano:');
         $this->addElement($nuAnoColaborador);
 

--- a/public/css/structure/form-style.css
+++ b/public/css/structure/form-style.css
@@ -85,11 +85,14 @@ form.form fieldset .chosen-container .chosen-results{
     font-size: 14px;
 }
 form.form fieldset .chosen-container .chosen-results li{
-    color: inherit;
+    color: #333333;
+    background-color: #ffffff;
     line-height: 20px;
+    padding: 6px 8px;
 }
 form.form fieldset .chosen-container .chosen-results li.highlighted{
     color: #ffffff;
+    background-color: #658DB5;
 }
 form.form fieldset textArea{
     height: 65px;

--- a/public/css/structure/form-style.css
+++ b/public/css/structure/form-style.css
@@ -74,6 +74,23 @@ form.form fieldset .chosen-container-single .chosen-single div b{
 form.form fieldset .chosen-container.chosen-disabled .chosen-single{
     background: #E5E5E5;
 }
+form.form fieldset .chosen-container .chosen-drop{
+    border: 1px solid #919090;
+    border-top: 0;
+    background: #ffffff;
+    box-shadow: 0 4px 5px rgba(0, 0, 0, 0.15);
+}
+form.form fieldset .chosen-container .chosen-results{
+    color: #333333;
+    font-size: 14px;
+}
+form.form fieldset .chosen-container .chosen-results li{
+    color: inherit;
+    line-height: 20px;
+}
+form.form fieldset .chosen-container .chosen-results li.highlighted{
+    color: #ffffff;
+}
 form.form fieldset textArea{
     height: 65px;
     font-size: 12px;

--- a/public/css/structure/form-style.css
+++ b/public/css/structure/form-style.css
@@ -48,12 +48,43 @@ form.form fieldset textArea{
     background:  #fafafa;
     margin-top: 2%;
 }
+form.form fieldset .chosen-container{
+    float: left;
+    width: 67% !important;
+    margin-top: 2%;
+}
+form.form fieldset .chosen-container-single .chosen-single{
+    height: 32px;
+    line-height: 32px;
+    border: 1px solid #919090;
+    border-radius: 5px;
+    background: #fafafa;
+    box-shadow: none;
+    padding: 0 35px 0 8px;
+}
+form.form fieldset .chosen-container-single .chosen-single span{
+    line-height: 32px;
+}
+form.form fieldset .chosen-container-single .chosen-single div{
+    width: 35px;
+}
+form.form fieldset .chosen-container-single .chosen-single div b{
+    background-position: 0 9px;
+}
+form.form fieldset .chosen-container.chosen-disabled .chosen-single{
+    background: #E5E5E5;
+}
 form.form fieldset textArea{
     height: 65px;
     font-size: 12px;
 }
-form.form fieldset input[type="text"]:focus, form.form fieldset select:focus, 
+form.form fieldset input[type="text"]:focus, form.form fieldset select:focus,
 form.form fieldset input[type="password"]:focus, form.form textArea:focus{
+    border: 1px solid #658DB5;
+    background: #ffffff;
+}
+form.form fieldset .chosen-container-active .chosen-single,
+form.form fieldset .chosen-container-single .chosen-single:hover{
     border: 1px solid #658DB5;
     background: #ffffff;
 }

--- a/public/js/livro/emprestimo/cadastrar_emprestimo.js
+++ b/public/js/livro/emprestimo/cadastrar_emprestimo.js
@@ -1,7 +1,9 @@
 $(function(){
 
+    var chosenConfig = {no_results_text: "Resultado não encontrado!"};
+    $('.chosen-select').chosen(chosenConfig);
 //$("select#idTurma").chosen({no_results_text: "Resultado não encontrado!"});
-	//$.prompt("<div class='loadGif'><img src='/img/structure/11.gif'><img></div>");
+        //$.prompt("<div class='loadGif'><img src='/img/structure/11.gif'><img></div>");
     var data = new Date();
     $("input#dtEmprestimo").mask("99/99/9999");    
     var dia = function(dia){
@@ -131,12 +133,13 @@ $(function(){
         $('div#mensagem').hide();
         var opcao = $(this).val();
         $('form fieldset').removeClass('selected');
-        $('select#idColaborador, select#idLivro, select#idTurma').val("");
-        $("select#noEvangelizando").html('<option label="Selecione a turma..." value="">Selecione a turma...</option>');
+        $('select#idColaborador, select#idLivro, select#idTurma').val("").trigger("chosen:updated");
+        $("select#noEvangelizando").html('<option label="Selecione a turma..." value="">Selecione a turma...</option>').trigger("chosen:updated");
         $("div#nuExemplar").hide();
+        $('select#nuExemplar').val("").trigger("chosen:updated");
         if(opcao === "evangelizando"){
             $('fieldset#evangelizando').addClass('selected');
-                    
+
         }else if(opcao === "colaborador"){
             $('fieldset#colaborador').addClass('selected');
         }
@@ -172,8 +175,8 @@ $(function(){
                 },
                 success: function(data, textStatus){
                     $('fieldset#evangelizandoTurma').addClass('selected');
-                    $('select#noEvangelizando').html(data);
-                                        
+                    $('select#noEvangelizando').html(data).trigger("chosen:updated");
+
                 },
                 error: function(xhr,er){                
                     new Messi('Erro interno, por favor entre em contato com o administrador.', {
@@ -183,6 +186,7 @@ $(function(){
             });
         }else{
             $('fieldset#evangelizandoTurma').removeClass('selected');
+            $('select#noEvangelizando').val("").trigger("chosen:updated");
         }
     });
     
@@ -215,8 +219,8 @@ $(function(){
                 },
                 success: function(data, textStatus){
                     $('div#nuExemplar').show();
-                    $('select#nuExemplar').html(data);
-                                        
+                    $('select#nuExemplar').html(data).trigger("chosen:updated");
+
                 },
                 error: function(xhr,er){                
                     new Messi('Erro interno, por favor entre em contato com o administrador.', {
@@ -226,6 +230,7 @@ $(function(){
             });
         }else{
             $('div#nuExemplar').hide();
+            $('select#nuExemplar').val("").trigger("chosen:updated");
         }
     });
        
@@ -242,9 +247,10 @@ $(function(){
             if(devLivro < 2){
                 $("input#dtPrevDevolucao").removeAttr('disabled');
                 $("select#nuExemplar").css("display","block");
+                $("select#nuExemplar").trigger("chosen:updated");
                 $('<input>').attr({
-                    type: 'hidden', 
-                    id: 'method', 
+                    type: 'hidden',
+                    id: 'method',
                     name: 'method'
                 }).val('save').appendTo('.form');
 		


### PR DESCRIPTION
## Summary
- add the `chosen-select` CSS class to the loan registration selects so they render with autocomplete support
- initialize the Chosen widget and refresh the dropdowns whenever their options change on the book loan registration page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4efc212a08328adc480569170cdcc